### PR TITLE
Fix OAS 3.1 validation JSON-schema by not using $dynamicRefs

### DIFF
--- a/src/Validation/v3.1.json
+++ b/src/Validation/v3.1.json
@@ -217,7 +217,7 @@
                 "schemas": {
                     "type": "object",
                     "additionalProperties": {
-                        "$dynamicRef": "#meta"
+                        "$ref": "#/$defs/schema"
                     }
                 },
                 "responses": {
@@ -466,7 +466,7 @@
                     "type": "boolean"
                 },
                 "schema": {
-                    "$dynamicRef": "#meta"
+                    "$ref": "#/$defs/schema"
                 },
                 "content": {
                     "$ref": "#/$defs/content",
@@ -708,7 +708,7 @@
             "type": "object",
             "properties": {
                 "schema": {
-                    "$dynamicRef": "#meta"
+                    "$ref": "#/$defs/schema"
                 },
                 "encoding": {
                     "type": "object",
@@ -967,7 +967,7 @@
                     "type": "boolean"
                 },
                 "schema": {
-                    "$dynamicRef": "#meta"
+                    "$ref": "#/$defs/schema"
                 },
                 "content": {
                     "$ref": "#/$defs/content",
@@ -1057,7 +1057,6 @@
         },
         "schema": {
             "$comment": "https://spec.openapis.org/oas/v3.1.0#schema-object",
-            "$dynamicAnchor": "meta",
             "type": [
                 "object",
                 "boolean"


### PR DESCRIPTION
This appears to be unsupported at this point in time
